### PR TITLE
feat: add lefthook for pre-push workflow automation

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,29 @@
+pre-push:
+  parallel: true
+  commands:
+    type-check:
+      run: pnpm run check
+      stage_fixed: false
+
+    lint:
+      run: pnpm run lint
+      stage_fixed: false
+
+    build:
+      run: pnpm run build
+      stage_fixed: false
+
+    test:
+      run: pnpm run test
+      stage_fixed: false
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: |
+        if ! echo "$1" | grep -qE "^(feat|fix|docs|style|refactor|test|chore)(\\(.+\\))?: .{1,50}"; then
+          echo "❌ Commit message must follow conventional format:"
+          echo "   <type>(<scope>): <description>"
+          exit 1
+        fi
+      stage_fixed: false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"prepare": "svelte-kit sync && panda codegen",
+		"prepare": "svelte-kit sync && panda codegen && lefthook install",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
@@ -23,6 +23,7 @@
 	},
 	"devDependencies": {
 		"@melt-ui/pp": "^0.3.2",
+		"lefthook": "^1.11.14",
 		"@melt-ui/svelte": "^0.81.0",
 		"@pandacss/dev": "^0.39.1",
 		"@pandacss/eslint-plugin": "^0.1.5",


### PR DESCRIPTION
## 概要
lefthookを導入してpush前のワークフロー自動化を実装しました。

## 変更内容
- [x] lefthook v1.11.14 をdevDependenciesに追加
- [x] lefthook.yml設定ファイルを作成
- [x] package.jsonのprepareスクリプトにlefthook installを追加
- [x] pre-pushフックで並列実行（型チェック・リント・ビルド・テスト）
- [x] コミットメッセージのconventional形式チェック

## その他
これにより、品質を保ちながら開発効率が向上します。