### PR TITLE
fix: update GitHub Actions to use ubuntu-latest and wrangler-action

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -7,22 +7,25 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       deployments: write
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-      - run: bun install
-      - run: bun run build
-
-      - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@1
+      - uses: actions/setup-node@v4
         with:
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - run: pnpm install
+      - run: pnpm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          projectName: nyatinte
-          branch: main
-          directory: .svelte-kit/cloudflare
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .svelte-kit/cloudflare --project-name=nyatinte


### PR DESCRIPTION
# Pull Request

## 概要
Ubuntu 20.04が2025年4月15日に廃止予定のため、GitHub Actionsワークフローを最新環境に更新しました。

## 変更内容
- [x] `runs-on: ubuntu-20.04` を `runs-on: ubuntu-latest` に更新
- [x] 廃止された `cloudflare/pages-action@1` を `cloudflare/wrangler-action@v3` に移行
- [x] bunからpnpmに変更してプロジェクト設定に統一
- [x] Node.js 20、pnpm latest version対応

## スクリーンショット
UI変更なし

## その他
GitHub Actions実行時のUbuntu 20.04廃止警告が解消されます。