### PR TITLE
fix: GitHub Actionsでのpnpmセットアップエラーを修正

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -7,22 +7,25 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       deployments: write
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-      - run: bun install
-      - run: bun run build
-
-      - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@1
+      - uses: actions/setup-node@v4
         with:
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - run: pnpm install
+      - run: pnpm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          projectName: nyatinte
-          branch: main
-          directory: .svelte-kit/cloudflare
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .svelte-kit/cloudflare --project-name=nyatinte

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -13,13 +13,15 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - run: pnpm install
       - run: pnpm run build
 


### PR DESCRIPTION
# Pull Request

## 概要

GitHub Actionsワークフローでpnpmがインストールされる前にキャッシュが呼び出されるエラーを修正し、bunからpnpmへの移行を完了しました。

## 変更内容

- [x] pnpmインストールをNode.jsセットアップより先に実行するよう順序修正
- [x] pnpmバージョンを10に指定（package.jsonのengines要件>=9に適合）
- [x] 各セットアップステップに説明的な名前を追加
- [x] CloudflareデプロイアクションをV3に更新
- [x] ubuntu-latestに更新

## スクリーンショット

N/A（GitHub Actionsワークフローの修正のため）

## その他

この修正により、Cloudflare Pagesへのデプロイが正常に動作するようになります。